### PR TITLE
enable TLS when using port 8883 without keyfiles

### DIFF
--- a/MQTTClient.py
+++ b/MQTTClient.py
@@ -317,7 +317,7 @@ class MQTTClient (mqtt.Client):
                              keyfile=self.cfg.MQTTBroker.clientkeyfile,
                              cert_reqs=ssl.CERT_REQUIRED)
             elif self.cfg.MQTTBroker.port==8883:
-                tls_set()
+                self.tls_set()
             res=self.connect(self.cfg.MQTTBroker.host,self.cfg.MQTTBroker.port)
             logging.debug(f"MQTT host connection result: {res}")
             if res>0:

--- a/MQTTClient.py
+++ b/MQTTClient.py
@@ -316,6 +316,8 @@ class MQTTClient (mqtt.Client):
                 self.tls_set(certfile=self.cfg.MQTTBroker.clientcertfile,
                              keyfile=self.cfg.MQTTBroker.clientkeyfile,
                              cert_reqs=ssl.CERT_REQUIRED)
+            elif self.cfg.MQTTBroker.port==8883:
+                tls_set()
             res=self.connect(self.cfg.MQTTBroker.host,self.cfg.MQTTBroker.port)
             logging.debug(f"MQTT host connection result: {res}")
             if res>0:


### PR DESCRIPTION
I suggest this PR in order to automatically enable TLS when using port 8883, even when not using client keyfiles but instead relying on user/pass auth with the broker.